### PR TITLE
don't set _data to HexbinLayer._data to null when layer is removed from map

### DIFF
--- a/src/js/hexbin/HexbinLayer.js
+++ b/src/js/hexbin/HexbinLayer.js
@@ -59,7 +59,7 @@
 
 			this._container = null;
 			this._map = null;
-			this._data = null;
+			this._data = [];
 		},
 
 		addTo : function(map) {


### PR DESCRIPTION
This fixes an exception when re-adding a HexbinLayer to a map, when it has
been removed before.

`HexbinLayer.onAdd()` calls `_redraw()` which tries to access `that._data` without checking it for null first. Previously this caused an exception if `onRemove()` had been called before.
By setting `_data` to [] instead of null, the exception is avoided without performing an additional check in `_redraw()`.