### PR TITLE
Replace 'opacity' attribute with 'fill-opacity' and 'stroke-opacity'

### DIFF
--- a/src/js/hexbin/HexbinLayer.js
+++ b/src/js/hexbin/HexbinLayer.js
@@ -171,13 +171,14 @@
 			// Update - set the fill and opacity on a transition (opacity is re-applied in case the enter transition was cancelled)
 			join.transition().duration(that.options.duration)
 				.attr('fill', function(d){ return that._colorScale(that.options.value(d)); })
-				.attr('opacity', that.options.opacity);
+				.attr('fill-opacity', that.options.opacity)
+				.attr('stroke-opacity', that.options.opacity);
 	
 			// Enter - establish the path, the fill, and the initial opacity
 			join.enter().append('path').attr('class', 'hexbin-hexagon')
 				.attr('d', function(d){ return 'M' + d.x + ',' + d.y + that._hexLayout.hexagon(); })
 				.attr('fill', function(d){ return that._colorScale(that.options.value(d)); })
-				.attr('opacity', 0.01)
+				.attr('fill-opacity', 0.01).attr('stroke-opacity', 0.01)
 				.on('mouseover', function(d, i) {
 					if(null != that.options.onmouseover) {
 						that.options.onmouseover(d, this, that);
@@ -194,11 +195,12 @@
 					}
 				})
 				.transition().duration(that.options.duration)
-					.attr('opacity', that.options.opacity);
+					.attr('fill-opacity', that.options.opacity)
+					.attr('stroke-opacity', that.options.opacity);
 
 			// Exit
 			join.exit().transition().duration(that.options.duration)
-				.attr('opacity', 0.01)
+				.attr('fill-opacity', 0.01).attr('stroke-opacity', 0.01)
 				.remove();
 
 		},


### PR DESCRIPTION
Using 'fill-opacity' and 'stroke-opacity' produces identical visuals in other browsers, but in IE, just using 'opacity' sometimes causes graphical glitches, whereas using 'fill-opacity' and 'stroke-opacity' works as expected.

Open http://jsfiddle.net/acjnbu8t/embedded/result/ in IE11 with WebGL enabled to see. This could occur on other setups, but that is the setup I have which is not working with 'opacity'.
