### PR TITLE
fix #54

### DIFF
--- a/src/js/hexbin/HexbinLayer.js
+++ b/src/js/hexbin/HexbinLayer.js
@@ -126,6 +126,8 @@ L.HexbinLayer = L.SVG.extend({
 
 		this._map = null;
 
+		d3.select(this._container).remove();
+
 		// Explicitly will leave the data array alone in case the layer will be shown again
 		//this._data = [];
 


### PR DESCRIPTION
This fixes a bug where Hexbin Layers could not be toggled off using Layers Control.

[Statzg](https://github.com/statzg) proposed this fix on Issue #54.

**Example of the bug**:
![hexbin_disable_720](https://user-images.githubusercontent.com/43001823/143723740-c9e6d3dd-156c-4296-9539-5dfa90641ba1.gif)

**Behavior after implementing fix**:
![done_720](https://user-images.githubusercontent.com/43001823/143723752-45ccf841-4cec-43e8-83c5-c4a6be1f8a60.gif)

 