### PR TITLE
fix: module path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"watch": " watch 'npm run build' ./src"
 	},
 	"main": "dist/leaflet-d3.js",
-	"module": "index.js",
+	"module": "src/js/index.js",
 	"typings": "index.d.ts",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Hi, I am in the process of writing a Vue JS wrapper for this plugin to add hexbin layers to [vue-leaflet](https://github.com/vue-leaflet/vue-leaflet) maps.
I was getting errors from Vite when importing `@asymmetrik/leaflet-d3` in my wrapper component. Turns out the `module` path in `package.json` was pointing to a non-existing file. This PR fixes it :slightly_smiling_face: 
Cheers